### PR TITLE
TMS-386: Remove navbar dropdown parent link from primary menu dropdown

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- TMS-386: Remove navbar dropdown parent link from primary menu dropdown
 - TMS-487: Improve back to top link hover & focus state visibility #85
 - TMS-486: Improve content link discernibility by adding an underline #84
 

--- a/assets/styles/overrides/_primary-nav.scss
+++ b/assets/styles/overrides/_primary-nav.scss
@@ -1,5 +1,8 @@
 .primary-nav {
     &--dropdown .navbar-dropdown {
         padding-top: 1.5rem;
+        &__parent-link {
+            display:none !important;
+        }
     }
 }

--- a/assets/styles/overrides/_primary-nav.scss
+++ b/assets/styles/overrides/_primary-nav.scss
@@ -1,0 +1,5 @@
+.primary-nav {
+    &--dropdown .navbar-dropdown {
+        padding-top: 1.5rem;
+    }
+}

--- a/assets/styles/overrides/index.scss
+++ b/assets/styles/overrides/index.scss
@@ -20,6 +20,7 @@
 @import "materials";
 @import "notice-banner";
 @import "pill";
+@import "primary-nav";
 @import "quote";
 @import "search";
 @import "share-links";


### PR DESCRIPTION
CR: https://geniemdev.atlassian.net/browse/TMS-10

## Description
Remove navbar dropdown parent link from primary menu dropdown with styles.

## Motivation and Context
[TMS-386](https://geniemdev.atlassian.net/browse/TMS-386)

## How Has This Been Tested?
Locally, staging

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
