### PR TITLE
TMS-768: Duet Date Picker active text color override

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- TMS-768: Duet Date Picker active text color override
+
 ## [1.15.0] - 2022-04-04
 
 ### Fixed

--- a/assets/styles/ui-components/_duetdatepicker.scss
+++ b/assets/styles/ui-components/_duetdatepicker.scss
@@ -1,3 +1,9 @@
+$duet-color-text-active: $white;
+
+:root {
+    --duet-color-text-active: #{$duet-color-text-active};
+}
+
 .duet-date {
     &__toggle-icon {
         color: $primary-invert !important; // sass-lint:disable-line no-important


### PR DESCRIPTION
## Description
Fix to issue where the active text color is same than the background color

## Motivation and Context
TMS-768 

## How Has This Been Tested?
Local

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
