### PR TITLE
TMS-1017: Add image alt-text to imported news single-article

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1017: Add image alt-text to imported news single-article
+
 ## [1.18.4] - 2023-11-21
 
 - TMS-997: Change textblock button border-color if no bg-color is selected

--- a/partials/single.dust
+++ b/partials/single.dust
@@ -23,7 +23,9 @@
 
                                     {?content.api_image_url}
                                         <div class="entry__figure pt-2 has-text-centered">
-                                            <img src="{content.api_image_url|url}" loading="lazy" />
+                                            <img src="{content.api_image_url|url}"
+                                             {?content.api_image_alt}alt="{content.api_image_alt|attr}"{/content.api_image_alt}
+                                             loading="lazy" />
                                         </div>
 
                                         {>"views/single/single-meta" spacing_class="pt-5 pt-4-desktop pb-5 p-5-tablet" /}


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1017 Drupalista tulevan uutisen pääkuvapaikan kuvan alt-teksti puuttuu
Task: https://hiondigital.atlassian.net/browse/TMS-1017

## Description
Add api-images alternative text to the news main-image if found

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
